### PR TITLE
Compare paths via os.path.samefile to ensure paths are normalized

### DIFF
--- a/nattka/__main__.py
+++ b/nattka/__main__.py
@@ -184,7 +184,7 @@ class NattkaCommands(object):
 
         repo = self.get_repository()
         git_repo = GitWorkTree(repo.location)
-        if git_repo.path != Path(repo.location):
+        if not git_repo.path.samefile(repo.location):
             log.critical(
                 f'{repo.location} does not seem to be a git repository')
             raise SystemExit(1)


### PR DESCRIPTION
Nattka would fail for me since I have the gentoo git in
~/data/code/gentoo/gentoo and a symlink from ~/code to ~/data/code. I
usually simply "cd ~/code/gentoo/gentoo". But then running nattka
would fail with

CRITICAL:nattka:/home/flo/code/gentoo/gentoo does not seem to be a git
repository

This is because the two compared Path objects, git_repo.path and
repo.location, have different values:

(Pdb) p repo.location
'/home/flo/code/gentoo/gentoo'

(Pdb) p git_repo.path
PosixPath('/home/flo/data/code/gentoo/gentoo')

Using os.path.samefile will normalize the path-like objects before
comparision, which fixes the issues for me.

Signed-off-by: Florian Schmaus <flow@gentoo.org>