### PR TITLE
bugzilla-instance updates

### DIFF
--- a/test/bugzilla-instance/Dockerfile
+++ b/test/bugzilla-instance/Dockerfile
@@ -1,10 +1,11 @@
 # based on the work of Max Magorsch
 # https://gitweb.gentoo.org/fork/bugzilla.git/commit/?id=92f934a30bdd615f9124c3107325d8884b89941a
 
-FROM gentoo/stage3-amd64-nomultilib
+FROM gentoo/stage3:amd64-nomultilib-openrc
 
 RUN echo "FEATURES=\"parallel-install -ebuild-locks\"" >> /etc/portage/make.conf \
- && echo "www-servers/apache apache2_modules_version apache2_mpms_prefork" > /etc/portage/package.use/apache \
+ && echo "www-servers/apache apache2_modules_version apache2_mpms_prefork -apache2_modules_http2" > /etc/portage/package.use/apache \
+ && echo "dev-perl/Type-Tiny-XS minimal" > /etc/portage/package.use/perl \
  && echo "dev-perl/Crypt-SMIME ~amd64" >> /etc/portage/package.accept_keywords \
  && echo "dev-perl/ExtUtils-CChecker ~amd64" >> /etc/portage/package.accept_keywords \
  && echo "dev-perl/GDGraph ~amd64" >> /etc/portage/package.accept_keywords \
@@ -13,16 +14,18 @@ RUN echo "FEATURES=\"parallel-install -ebuild-locks\"" >> /etc/portage/make.conf
  && echo "dev-perl/GD-Graph3d ~amd64" >> /etc/portage/package.accept_keywords \
  && echo "dev-perl/XMLRPC-Lite ~amd64" >> /etc/portage/package.accept_keywords \
  && echo "dev-perl/Template-GD ~amd64" >> /etc/portage/package.accept_keywords \
- && echo "dev-perl/GDTextUtil ~amd64" >> /etc/portage/package.accept_keywords \
- && wget --progress=dot:mega -O - https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz | tar -xz \
+ && echo "dev-perl/GDTextUtil ~amd64" >> /etc/portage/package.accept_keywords
+
+RUN wget --progress=dot:mega -O - https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz | tar -xz \
  && mv gentoo-master /var/db/repos/gentoo \
  && mkdir -p /var/www/localhost/htdocs \
  && wget --progress=dot:mega -O - https://gitweb.gentoo.org/fork/bugzilla.git/snapshot/master.tar.gz | tar -xz \
- && mv master /var/www/localhost/htdocs/bugzilla \
- && emerge -1v --jobs $(nproc) www-servers/apache dev-perl/CGI dev-perl/TimeDate dev-perl/DateTime dev-perl/DateTime-TimeZone dev-perl/DBI dev-perl/Template-Toolkit dev-perl/Email-Sender dev-perl/Email-MIME dev-perl/URI dev-perl/List-MoreUtils dev-perl/Math-Random-ISAAC dev-perl/JSON-XS dev-perl/Crypt-OpenPGP dev-perl/Crypt-SMIME dev-perl/HTML-Tree dev-perl/DBD-SQLite dev-perl/JSON-RPC dev-perl/Test-Taint \
- && rm -rf /var/db/repos/gentoo \
+ && mv master /var/www/localhost/htdocs/bugzilla
+
+RUN emerge -1v --jobs $(nproc) www-servers/apache dev-perl/CGI dev-perl/TimeDate dev-perl/DateTime dev-perl/DateTime-TimeZone dev-perl/DBI dev-perl/Template-Toolkit dev-perl/Email-Sender dev-perl/Email-MIME dev-perl/URI dev-perl/List-MoreUtils dev-perl/Math-Random-ISAAC dev-perl/JSON-XS dev-perl/Crypt-OpenPGP dev-perl/Crypt-SMIME dev-perl/HTML-Tree dev-perl/DBD-SQLite dev-perl/JSON-RPC dev-perl/Test-Taint \
  && usermod -u 1000 apache \
- && groupmod -g 1000 apache
+ && groupmod -g 1000 apache \
+ && rm -rf /var/db/repos/gentoo
 
 WORKDIR /var/www/localhost/htdocs/bugzilla
 

--- a/test/bugzilla-instance/bugzilla.sql
+++ b/test/bugzilla-instance/bugzilla.sql
@@ -43,11 +43,11 @@ INSERT INTO flaginclusions VALUES(1,2,4);
 INSERT INTO flaginclusions VALUES(1,1,2);
 INSERT INTO flaginclusions VALUES(1,1,3);
 
-INSERT INTO profiles VALUES(2,'nattka@gentoo.org','exWOmCFt,R9v10azPGMUR5svpxz+PTFAKI0pnlYJm/m5J8jHaiJw{SHA-256}','NATTkA','',0,1,NULL,1,NULL);
-INSERT INTO profiles VALUES(3,'alpha@gentoo.org','LKdqphPk,AvLMtVEe+k1+v+L6l1e7hkAfPt9mhGWTOrjb03IIIME{SHA-256}','ALPHA arch team','',0,1,NULL,1,NULL);
-INSERT INTO profiles VALUES(4,'amd64@gentoo.org','cBneojLv,YOqI18zh5tbvIPF+4HMM1d6r4thzl8tLHrlg8caVkB4{SHA-256}','AMD64 arch team','',0,1,NULL,1,NULL);
-INSERT INTO profiles VALUES(5,'hppa@gentoo.org','n5cNYDsd,j3jmz7bqI42q2HfnjommYGglvYmCdAfqoxqH9JLfb3E{SHA-256}','HPPA arch team','',0,1,NULL,1,NULL);
-INSERT INTO profiles VALUES(6,'bug-wranglers@gentoo.org','11UExTQa,AXhW464TxhzrI2nRP4d5l+TqOupCEFUkuPp44rDJOwU{SHA-256}','Bug wranglers','',0,1,NULL,1,NULL);
+INSERT INTO profiles VALUES(2,'nattka@gentoo.org','exWOmCFt,R9v10azPGMUR5svpxz+PTFAKI0pnlYJm/m5J8jHaiJw{SHA-256}','NATTkA','',0,1,NULL,1,NULL,'1900-01-01 00:00:00');
+INSERT INTO profiles VALUES(3,'alpha@gentoo.org','LKdqphPk,AvLMtVEe+k1+v+L6l1e7hkAfPt9mhGWTOrjb03IIIME{SHA-256}','ALPHA arch team','',0,1,NULL,1,NULL,'1900-01-01 00:00:00');
+INSERT INTO profiles VALUES(4,'amd64@gentoo.org','cBneojLv,YOqI18zh5tbvIPF+4HMM1d6r4thzl8tLHrlg8caVkB4{SHA-256}','AMD64 arch team','',0,1,NULL,1,NULL,'1900-01-01 00:00:00');
+INSERT INTO profiles VALUES(5,'hppa@gentoo.org','n5cNYDsd,j3jmz7bqI42q2HfnjommYGglvYmCdAfqoxqH9JLfb3E{SHA-256}','HPPA arch team','',0,1,NULL,1,NULL,'1900-01-01 00:00:00');
+INSERT INTO profiles VALUES(6,'bug-wranglers@gentoo.org','11UExTQa,AXhW464TxhzrI2nRP4d5l+TqOupCEFUkuPp44rDJOwU{SHA-256}','Bug wranglers','',0,1,NULL,1,NULL,'1900-01-01 00:00:00');
 
 INSERT INTO user_api_keys VALUES(1,2,'xH3pICxBPtyhTrFjvuuzIaNYek9uqisCJzR9izAZ','testing',0,NULL);
 INSERT INTO user_api_keys VALUES(2,1,'dhaGUYKZOGGVRmg4k24wEXaWRHntUjIlW6eqePu1','testing',0,NULL);


### PR DESCRIPTION
Currently, the container isn't buildable thanks to the currently used image no longer being updated, EAPI=8 being unavailable despite using current gentoo.git master, and a profiles table update. This should fix up everything so that the container builds again.

The main thing that might be controversial is the splitting of the RUNs in the Dockerfile, this is done so that one command failling (say, `emerge` fails) doesn't cause redoing all of the commands (particularly unwanted would be refetching gentoo.git and bugzilla.git).