### PR TITLE
Auto cc maintainers on CC-ARCHES

### DIFF
--- a/nattka/__main__.py
+++ b/nattka/__main__.py
@@ -610,6 +610,7 @@ class NattkaCommands(object):
                 check_res: typing.Optional[bool] = None
                 cache_entry: typing.Optional[dict] = None
                 cc_arches: typing.List[str] = []
+                cc_maintainers: typing.List[str] = []
                 allarches_chg = False
                 expanded_plist: typing.Optional[str] = None
                 need_security_kw = False
@@ -674,13 +675,16 @@ class NattkaCommands(object):
                                 f'dependent bug #{kw_dep} has errors')
 
                     # check if we have arches to CC
-                    if ('CC-ARCHES' in b.keywords and not arches_cced
-                            and b.assigned_to != 'bug-wranglers@gentoo.org'):
-                        cc_arches = sorted(
-                            [f'{x}@gentoo.org' for x
-                             in set(filter_prefix_keywords(
-                                 itertools.chain.from_iterable(
-                                     check_packages.values())))])
+                    if 'CC-ARCHES' in b.keywords and not arches_cced:
+                        if b.assigned_to != 'bug-wranglers@gentoo.org':
+                            cc_arches = sorted(
+                                [f'{x}@gentoo.org' for x
+                                in set(filter_prefix_keywords(
+                                    itertools.chain.from_iterable(
+                                        check_packages.values())))])
+                        cc_maintainers = sorted(
+                            set(m.email for m in itertools.chain.from_iterable(
+                                pkg.maintainers for pkg in check_packages.keys())).difference(b.cc).difference([b.assigned_to]))
 
                     # check if we have ALLARCHES to toggle
                     allarches = (b.category == BugCategory.STABLEREQ
@@ -849,6 +853,8 @@ class NattkaCommands(object):
 
                 if cc_arches:
                     log.info(f'CC arches: {" ".join(cc_arches)}')
+                if cc_maintainers:
+                    log.info(f'CC maintainers: {" ".join(cc_maintainers)}')
                 if allarches_chg:
                     log.info(f'{"Adding" if allarches else "Removing"} '
                              f'ALLARCHES')
@@ -861,7 +867,7 @@ class NattkaCommands(object):
                 if self.args.update_bugs:
                     kwargs = {}
                     if cc_arches:
-                        kwargs['cc_add'] = cc_arches
+                        kwargs['cc_add'] = cc_arches + cc_maintainers
                     keywords_add = []
                     if allarches_chg:
                         if allarches:

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1587,7 +1587,7 @@ class IntegrationSuccessTests(IntegrationTestCase):
         bugz_inst.find_bugs.assert_called_with(bugs=[560322])
         bugz_inst.update_status.assert_called_with(
             560322, True, None,
-            cc_add=['amd64@gentoo.org', 'hppa@gentoo.org'],
+            cc_add=['amd64@gentoo.org', 'hppa@gentoo.org', 'foo@example.com'],
             new_package_list=['test/mixed-keywords-3 \r\n'
                               'test/amd64-testing-2 \r\n'])
         self.post_verify()
@@ -1677,7 +1677,7 @@ class IntegrationSuccessTests(IntegrationTestCase):
         bugz_inst.find_bugs.assert_called_with(bugs=[560322])
         bugz_inst.update_status.assert_called_with(
             560322, True, None,
-            cc_add=['amd64@gentoo.org', 'hppa@gentoo.org'])
+            cc_add=['amd64@gentoo.org', 'hppa@gentoo.org', 'foo@example.com'])
         self.post_verify()
 
     @patch('nattka.__main__.NattkaBugzilla')


### PR DESCRIPTION
Resolves: #49

I will explain the effects of this PR, so if some flow is wrong, it would be easy to understand and fix.

1. bug without `CC-ARCHES` - ignore
2. bug with arches already CC - ignore
3. bug assigned to `bug-wranglers@gentoo.org` - CC maintainers (this one might be controversial - input would be nice)
4. bug not assigned to `bug-wranglers@gentoo.org` - CC arches & maintainers

All maintainers from all packages in list are selected, after subtracting all already CC maintainers and assigned.

Improvement point: maybe auto select the assignee? If yes, which one?